### PR TITLE
Bump upper pin of `cryptography`

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - 0001-Fixes-for-conda-build-with-Arrow-support.patch  # [not win]
 
 build:
-  number: 0
+  number: 1
   skip: true  # [py2k]
   script:
     - ENABLE_EXT_MODULES=true {{ PYTHON }} -m pip install . --no-deps -vvv    # [unix]
@@ -42,7 +42,7 @@ requirements:
     - boto3 >=1.4.4,<1.16
     - certifi <2021.0.0
     - cffi >=1.9,<1.15
-    - cryptography >=2.5.0,<3.0.0
+    - cryptography >=2.5.0,<4.0.0
     - idna <2.11
     - oscrypto <2.0.0
     - pandas >=1,<1.1


### PR DESCRIPTION
Version 2.3.5 updated their `cryptography` pin range (mostly, I believe, to get around CVE-2020-25659) -- just updating that upper pin here.

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [x] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
