### PR TITLE
Add run_constrained for optional keyring dependency

### DIFF
--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -12,7 +12,7 @@ source:
     - setup.py.patch  # remove version numbers for arrow/pyarrow
 
 build:
-  number: 0
+  number: 1
   script:
     - export SF_NO_COPY_ARROW_LIB=1              # [unix]
     - export SF_ARROW_LIBDIR="${PREFIX}/lib"     # [unix]
@@ -70,6 +70,8 @@ requirements:
     - dataclasses <1  # [py<37]
   run_constrained:
     - pandas >1,<1.3
+    # optional dependency for the [secure-local-storage] extra in the pypi package
+    - keyring <22.0.0,!=16.1.0"
 
 test:
   requires:


### PR DESCRIPTION
This should allow us to install keyring alongside snowflake-connector and have it within the constraints from `extras_require["secure-local-storage"]`

<!--
Thank you for pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [ ] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
