### PR TITLE
Raised crypo dependencies

### DIFF
--- a/recipe/0001-patch-cryptography-deps.patch
+++ b/recipe/0001-patch-cryptography-deps.patch
@@ -1,0 +1,41 @@
+From 36485789264c01a6706ef05ed6237f0d0726a23c Mon Sep 17 00:00:00 2001
+From: Adam Ling <adam.ling@snowflake.com>
+Date: Mon, 29 Jan 2024 16:56:43 -0800
+Subject: [PATCH] bump dependency
+
+---
+ DESCRIPTION.md | 5 +++++
+ setup.cfg      | 4 ++--
+ 2 files changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/DESCRIPTION.md b/DESCRIPTION.md
+index 8de5d5e3d..fe98408ea 100644
+--- a/DESCRIPTION.md
++++ b/DESCRIPTION.md
+@@ -8,6 +8,11 @@ Source code is also available at: https://github.com/snowflakedb/snowflake-conne
+ 
+ # Release Notes
+ 
++- v3.7.1
++
++  - Bumped cryptography dependency from <42.0.0,>=3.1.0 to >=3.1.0,<43.0.0.
++  - Bumped pyOpenSSL dependency from >=16.2.0,<24.0.0 to >=16.2.0,<25.0.0.
++
+ - v3.7.0(January 25,2024)
+ 
+   - Added a new boolean parameter `force_return_table` to `SnowflakeCursor.fetch_arrow_all` to force returning `pyarrow.Table` in case of zero rows.
+diff --git a/setup.cfg b/setup.cfg
+index 4012abe04..e335fb1a5 100644
+--- a/setup.cfg
++++ b/setup.cfg
+@@ -45,8 +45,8 @@ packages = find_namespace:
+ install_requires =
+     asn1crypto>0.24.0,<2.0.0
+     cffi>=1.9,<2.0.0
+-    cryptography>=3.1.0,<42.0.0
+-    pyOpenSSL>=16.2.0,<24.0.0
++    cryptography>=3.1.0,<43.0.0
++    pyOpenSSL>=16.2.0,<25.0.0
+     pyjwt<3.0.0
+     pytz
+     requests<3.0.0

--- a/recipe/meta.yaml
+++ b/recipe/meta.yaml
@@ -8,9 +8,11 @@ package:
 source:
   url: https://github.com/snowflakedb/{{ name }}/archive/refs/tags/v{{ version }}.tar.gz
   sha256: 27f99807ddcfab19303f5faea7f174386949496d2d05e67ed19c401c973a8110
+  patches:
+    - 0001-patch-cryptography-deps.patch
 
 build:
-  number: 0
+  number: 1
   entry_points:
     - snowflake-dump-ocsp-response = snowflake.connector.tool.dump_ocsp_response:main
     - snowflake-dump-ocsp-response-cache = snowflake.connector.tool.dump_ocsp_response_cache:main
@@ -40,8 +42,8 @@ requirements:
     - python
     - asn1crypto >0.24.0,<2.0.0
     - cffi >=1.9,<2.0.0
-    - cryptography >=3.1.0,<42.0.0
-    - pyOpenSSL >=16.2.0,<24.0.0
+    - cryptography >=3.1.0,<43.0.0
+    - pyOpenSSL >=16.2.0,<25.0.0
     - pyjwt <3.0.0
     - pytz
     - requests <3.0.0


### PR DESCRIPTION
<!--
Thank you for your pull request.
Below are a few things we ask you kindly to self-check before getting a review. Remove checks that are not relevant.
-->
Checklist
* [x] Used a [personal fork of the feedstock to propose changes](https://conda-forge.org/docs/maintainer/updating_pkgs.html#forking-and-pull-requests)
* [x] Bumped the build number (if the version is unchanged)
* [ ] Reset the build number to `0` (if the version changed)
* [x] [Re-rendered]( https://conda-forge.org/docs/maintainer/updating_pkgs.html#rerendering-feedstocks ) with the latest `conda-smithy` (Use the phrase <code>@<space/>conda-forge-admin, please rerender</code> in a comment in this PR for automated rerendering)
* [x] Ensured the license file is being packaged.

<!--
Please note any issues this fixes using [closing keywords]( https://help.github.com/articles/closing-issues-using-keywords/ ):
-->

<!--
Please add any other relevant info below:
-->
Currently snowflake-connector-python pins a vulnerable cryptography version. On main this dependency was already changed (without required compatibility fixes apparently): https://github.com/snowflakedb/snowflake-connector-python/pull/1866
I would therefore already increase the dependency in the feedstock despite not having a new snowflake-connector release.